### PR TITLE
Add `assertIO` method to simplify asserting `IO`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target
 .metals
 .bloop
 .idea
+**/metals.sbt
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .idea
 **/metals.sbt
 .vscode
+.bsp

--- a/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -17,6 +17,9 @@
 package munit
 
 import cats.effect.IO
+import cats.syntax.eq._
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 trait CatsEffectAssertions { self: Assertions =>
 
@@ -43,6 +46,94 @@ trait CatsEffectAssertions { self: Assertions =>
       clue: => Any = "values are not the same"
   )(implicit loc: Location, ev: B <:< A): IO[Unit] =
     obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
+
+  /**
+    * Intercepts a `Throwable` being thrown inside the provided `IO`.
+    *
+    * @example
+    * {{{
+    *   val io = IO.raiseError[Unit](MyException("BOOM!"))
+    *
+    *   interceptIO[MyException](io)
+    * }}}
+    *
+    * or
+    *
+    * {{{
+    *   interceptIO[MyException] {
+    *       IO.raiseError[Unit](MyException("BOOM!"))
+    *   }
+    * }}}
+    */
+  def interceptIO[T <: Throwable](io: IO[Any])(implicit T: ClassTag[T], loc: Location): IO[T] =
+    io.attempt.flatMap[T](runInterceptIO(None))
+
+  /**
+    * Intercepts a `Throwable` with a certain message being thrown inside the provided `IO`.
+    *
+    * @example
+    * {{{
+    *   val io = IO.raiseError[Unit](MyException("BOOM!"))
+    *
+    *   interceptIO[MyException]("BOOM!")(io)
+    * }}}
+    *
+    * or
+    *
+    * {{{
+    *   interceptIO[MyException] {
+    *       IO.raiseError[Unit](MyException("BOOM!"))
+    *   }
+    * }}}
+    */
+  def interceptMessageIO[T <: Throwable](
+      expectedExceptionMessage: String
+  )(io: IO[Any])(implicit T: ClassTag[T], loc: Location): IO[T] =
+    io.attempt.flatMap[T](runInterceptIO(Some(expectedExceptionMessage)))
+
+  /**
+    * Copied from `munit.Assertions` and adapted to return `IO[T]` instead of `T`.
+    */
+  private def runInterceptIO[T <: Throwable](
+      expectedExceptionMessage: Option[String]
+  )(implicit T: ClassTag[T], loc: Location): Either[Throwable, Any] => IO[T] = {
+    case Right(value) =>
+      IO {
+        fail(
+          s"expected exception of type '${T.runtimeClass.getName()}' but body evaluated successfully",
+          clues(value)
+        )
+      }
+    case Left(e: FailException) if !T.runtimeClass.isAssignableFrom(e.getClass()) =>
+      IO.raiseError[T](e)
+    case Left(NonFatal(e: T))
+        if expectedExceptionMessage.map(_ === e.getMessage()).getOrElse(true) =>
+      IO(e)
+    case Left(NonFatal(e: T)) =>
+      IO.raiseError[T] {
+        val obtained = e.getClass().getName()
+
+        new FailException(
+          s"intercept failed, exception '$obtained' had message '${e.getMessage}', " +
+            s"which was different from expected message '${expectedExceptionMessage.get}'",
+          cause = e,
+          isStackTracesEnabled = false,
+          location = loc
+        )
+      }
+    case Left(NonFatal(e)) =>
+      IO.raiseError[T] {
+        val obtained = e.getClass().getName()
+        val expected = T.runtimeClass.getName()
+
+        new FailException(
+          s"intercept failed, exception '$obtained' is not a subtype of '$expected",
+          cause = e,
+          isStackTracesEnabled = false,
+          location = loc
+        )
+      }
+  }
 
 }
 

--- a/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -25,8 +25,7 @@ import cats.effect.Sync
 
 trait CatsEffectAssertions { self: Assertions =>
 
-  /**
-    * Asserts that an [[IO]] returns an expected value.
+  /** Asserts that an [[IO]] returns an expected value.
     *
     * The "returns" value (second argument) must have the same type or be a
     * subtype of the one "contained" inside the `IO` (first argument). For example:
@@ -49,8 +48,7 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location, ev: B <:< A): IO[Unit] =
     obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
 
-  /**
-    * Intercepts a `Throwable` being thrown inside the provided `IO`.
+  /** Intercepts a `Throwable` being thrown inside the provided `IO`.
     *
     * @example
     * {{{
@@ -70,8 +68,7 @@ trait CatsEffectAssertions { self: Assertions =>
   def interceptIO[T <: Throwable](io: IO[Any])(implicit T: ClassTag[T], loc: Location): IO[T] =
     io.attempt.flatMap[T](runInterceptF[IO, T](None))
 
-  /**
-    * Intercepts a `Throwable` with a certain message being thrown inside the provided `IO`.
+  /** Intercepts a `Throwable` with a certain message being thrown inside the provided `IO`.
     *
     * @example
     * {{{
@@ -93,8 +90,7 @@ trait CatsEffectAssertions { self: Assertions =>
   )(io: IO[Any])(implicit T: ClassTag[T], loc: Location): IO[T] =
     io.attempt.flatMap[T](runInterceptF[IO, T](Some(expectedExceptionMessage)))
 
-  /**
-    * Asserts that a [[SyncIO]] returns an expected value.
+  /** Asserts that a [[SyncIO]] returns an expected value.
     *
     * The "returns" value (second argument) must have the same type or be a
     * subtype of the one "contained" inside the `SyncIO` (first argument). For example:
@@ -117,8 +113,7 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location, ev: B <:< A): SyncIO[Unit] =
     obtained.flatMap(a => SyncIO(assertEquals(a, returns, clue)))
 
-  /**
-    * Intercepts a `Throwable` being thrown inside the provided `SyncIO`.
+  /** Intercepts a `Throwable` being thrown inside the provided `SyncIO`.
     *
     * @example
     * {{{
@@ -140,8 +135,7 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit T: ClassTag[T], loc: Location): SyncIO[T] =
     io.attempt.flatMap[T](runInterceptF[SyncIO, T](None))
 
-  /**
-    * Intercepts a `Throwable` with a certain message being thrown inside the provided `SyncIO`.
+  /** Intercepts a `Throwable` with a certain message being thrown inside the provided `SyncIO`.
     *
     * @example
     * {{{
@@ -163,8 +157,7 @@ trait CatsEffectAssertions { self: Assertions =>
   )(io: SyncIO[Any])(implicit T: ClassTag[T], loc: Location): SyncIO[T] =
     io.attempt.flatMap[T](runInterceptF[SyncIO, T](Some(expectedExceptionMessage)))
 
-  /**
-    * Copied from `munit.Assertions` and adapted to return `IO[T]` instead of `T`.
+  /** Copied from `munit.Assertions` and adapted to return `IO[T]` instead of `T`.
     */
   private def runInterceptF[F[_]: Sync, T <: Throwable](
       expectedExceptionMessage: Option[String]
@@ -209,8 +202,7 @@ trait CatsEffectAssertions { self: Assertions =>
 
   implicit class MUnitCatsAssertionsForIOOps[A](io: IO[A]) {
 
-    /**
-      * Asserts that this effect returns an expected value.
+    /** Asserts that this effect returns an expected value.
       *
       * The "expected" value (second argument) must have the same type or be a
       * subtype of the one "contained" inside the effect. For example:
@@ -231,8 +223,7 @@ trait CatsEffectAssertions { self: Assertions =>
     )(implicit loc: Location, ev: B <:< A): IO[Unit] =
       assertIO(io, expected, clue)
 
-    /**
-      * Intercepts a `Throwable` being thrown inside this effect.
+    /** Intercepts a `Throwable` being thrown inside this effect.
       *
       * @example
       * {{{
@@ -244,8 +235,7 @@ trait CatsEffectAssertions { self: Assertions =>
     def intercept[T <: Throwable](implicit T: ClassTag[T], loc: Location): IO[T] =
       interceptIO[T](io)
 
-    /**
-      * Intercepts a `Throwable` with a certain message being thrown inside this effect.
+    /** Intercepts a `Throwable` with a certain message being thrown inside this effect.
       *
       * @example
       * {{{
@@ -263,8 +253,7 @@ trait CatsEffectAssertions { self: Assertions =>
 
   implicit class MUnitCatsAssertionsForSyncIOOps[A](io: SyncIO[A]) {
 
-    /**
-      * Asserts that this effect returns an expected value.
+    /** Asserts that this effect returns an expected value.
       *
       * The "expected" value (second argument) must have the same type or be a
       * subtype of the one "contained" inside the effect. For example:
@@ -285,8 +274,7 @@ trait CatsEffectAssertions { self: Assertions =>
     )(implicit loc: Location, ev: B <:< A): SyncIO[Unit] =
       assertSyncIO(io, expected, clue)
 
-    /**
-      * Intercepts a `Throwable` being thrown inside this effect.
+    /** Intercepts a `Throwable` being thrown inside this effect.
       *
       * @example
       * {{{
@@ -298,8 +286,7 @@ trait CatsEffectAssertions { self: Assertions =>
     def intercept[T <: Throwable](implicit T: ClassTag[T], loc: Location): SyncIO[T] =
       interceptSyncIO[T](io)
 
-    /**
-      * Intercepts a `Throwable` with a certain message being thrown inside this effect.
+    /** Intercepts a `Throwable` with a certain message being thrown inside this effect.
       *
       * @example
       * {{{

--- a/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -207,6 +207,114 @@ trait CatsEffectAssertions { self: Assertions =>
       }
   }
 
+  implicit class MUnitCatsAssertionsForIOOps[A](io: IO[A]) {
+
+    /**
+      * Asserts that this effect returns an expected value.
+      *
+      * The "expected" value (second argument) must have the same type or be a
+      * subtype of the one "contained" inside the effect. For example:
+      * {{{
+      *   IO(Option(1)).assertEquals(Some(1)) // OK
+      *   IO(Some(1)).assertEquals(Option(1)) // Error: Option[Int] is not a subtype of Some[Int]
+      * }}}
+      *
+      * The "clue" value can be used to give extra information about the failure in case the
+      * assertion fails.
+      *
+      * @param expected the expected value
+      * @param clue a value that will be printed in case the assertions fails
+      */
+    def assertEquals[B](
+        expected: B,
+        clue: => Any = "values are not the same"
+    )(implicit loc: Location, ev: B <:< A): IO[Unit] =
+      assertIO(io, expected, clue)
+
+    /**
+      * Intercepts a `Throwable` being thrown inside this effect.
+      *
+      * @example
+      * {{{
+      *   val io = IO.raiseError[Unit](MyException("BOOM!"))
+      *
+      *   io.intercept[MyException]
+      * }}}
+      */
+    def intercept[T <: Throwable](implicit T: ClassTag[T], loc: Location): IO[T] =
+      interceptIO[T](io)
+
+    /**
+      * Intercepts a `Throwable` with a certain message being thrown inside this effect.
+      *
+      * @example
+      * {{{
+      *   val io = IO.raiseError[Unit](MyException("BOOM!"))
+      *
+      *   io.intercept[MyException]("BOOM!")
+      * }}}
+      */
+    def interceptMessage[T <: Throwable](
+        expectedExceptionMessage: String
+    )(implicit T: ClassTag[T], loc: Location): IO[T] =
+      interceptMessageIO[T](expectedExceptionMessage)(io)
+
+  }
+
+  implicit class MUnitCatsAssertionsForSyncIOOps[A](io: SyncIO[A]) {
+
+    /**
+      * Asserts that this effect returns an expected value.
+      *
+      * The "expected" value (second argument) must have the same type or be a
+      * subtype of the one "contained" inside the effect. For example:
+      * {{{
+      *   SyncIO(Option(1)).assertEquals(Some(1)) // OK
+      *   SyncIO(Some(1)).assertEquals(Option(1)) // Error: Option[Int] is not a subtype of Some[Int]
+      * }}}
+      *
+      * The "clue" value can be used to give extra information about the failure in case the
+      * assertion fails.
+      *
+      * @param expected the expected value
+      * @param clue a value that will be printed in case the assertions fails
+      */
+    def assertEquals[B](
+        expected: B,
+        clue: => Any = "values are not the same"
+    )(implicit loc: Location, ev: B <:< A): SyncIO[Unit] =
+      assertSyncIO(io, expected, clue)
+
+    /**
+      * Intercepts a `Throwable` being thrown inside this effect.
+      *
+      * @example
+      * {{{
+      *   val io = SyncIO.raiseError[Unit](MyException("BOOM!"))
+      *
+      *   io.intercept[MyException]
+      * }}}
+      */
+    def intercept[T <: Throwable](implicit T: ClassTag[T], loc: Location): SyncIO[T] =
+      interceptSyncIO[T](io)
+
+    /**
+      * Intercepts a `Throwable` with a certain message being thrown inside this effect.
+      *
+      * @example
+      * {{{
+      *   val io = SyncIO.raiseError[Unit](MyException("BOOM!"))
+      *
+      *   io.intercept[MyException]("BOOM!")
+      * }}}
+      */
+    def interceptMessage[T <: Throwable](
+        expectedExceptionMessage: String
+    )(implicit T: ClassTag[T], loc: Location): SyncIO[T] =
+      interceptMessageSyncIO[T](expectedExceptionMessage)(io)
+
+  }
+
 }
 
 object CatsEffectAssertions extends Assertions with CatsEffectAssertions

--- a/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+
+trait CatsEffectAssertions { self: Assertions =>
+
+  /**
+    * Asserts that an [[IO]] returns an expected value.
+    *
+    * The "returns" value (second argument) must have the same type or be a
+    * subtype of the one "contained" inside the `IO` (first argument). For example:
+    * {{{
+    *   assertIO(IO(Option(1)), returns = Some(1)) // OK
+    *   assertIO(IO(Some(1)), returns = Option(1)) // Error: Option[Int] is not a subtype of Some[Int]
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the
+    * assertion fails.
+    *
+    * @param obtained the IO under testing
+    * @param returns the expected value
+    * @param clue a value that will be printed in case the assertions fails
+    */
+  def assertIO[A, B](
+      obtained: IO[A],
+      returns: B,
+      clue: => Any = "values are not the same"
+  )(implicit loc: Location, ev: B <:< A): IO[Unit] =
+    obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
+
+}
+
+object CatsEffectAssertions extends Assertions with CatsEffectAssertions

--- a/core/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -22,6 +22,30 @@ import scala.concurrent.Future
 
 abstract class CatsEffectSuite extends FunSuite {
 
+  /**
+    * Asserts that an [[IO]] returns an expected value.
+    *
+    * The "returns" value (second argument) must have the same type or be a
+    * subtype of the one "contained" inside the `IO` (first argument). For example:
+    * {{{
+    *   assertIO(IO(Option(1)), returns = Some(1)) // OK
+    *   assertIO(IO(Some(1)), returns = Option(1)) // Error: Option[Int] is not a subtype of Some[Int]
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the
+    * assertion fails.
+    *
+    * @param obtained the IO under testing
+    * @param returns the expected value
+    * @param clue a value that will be printed in case the assertions fails
+    */
+  def assertIO[A, B](
+      obtained: IO[A],
+      returns: B,
+      clue: => Any = "values are not the same"
+  )(implicit loc: Location, ev: B <:< A): IO[Unit] =
+    obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
+
   implicit def munitContextShift: ContextShift[IO] =
     IO.contextShift(munitExecutionContext)
 

--- a/core/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -20,31 +20,7 @@ import cats.effect.{ContextShift, IO, SyncIO, Timer}
 
 import scala.concurrent.Future
 
-abstract class CatsEffectSuite extends FunSuite {
-
-  /**
-    * Asserts that an [[IO]] returns an expected value.
-    *
-    * The "returns" value (second argument) must have the same type or be a
-    * subtype of the one "contained" inside the `IO` (first argument). For example:
-    * {{{
-    *   assertIO(IO(Option(1)), returns = Some(1)) // OK
-    *   assertIO(IO(Some(1)), returns = Option(1)) // Error: Option[Int] is not a subtype of Some[Int]
-    * }}}
-    *
-    * The "clue" value can be used to give extra information about the failure in case the
-    * assertion fails.
-    *
-    * @param obtained the IO under testing
-    * @param returns the expected value
-    * @param clue a value that will be printed in case the assertions fails
-    */
-  def assertIO[A, B](
-      obtained: IO[A],
-      returns: B,
-      clue: => Any = "values are not the same"
-  )(implicit loc: Location, ev: B <:< A): IO[Unit] =
-    obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
+abstract class CatsEffectSuite extends FunSuite with CatsEffectAssertions {
 
   implicit def munitContextShift: ContextShift[IO] =
     IO.contextShift(munitExecutionContext)

--- a/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -17,6 +17,7 @@
 package munit
 
 import cats.effect.IO
+import cats.syntax.all._
 import scala.concurrent.duration._
 
 class CatsEffectAssertionsSpec extends CatsEffectSuite {
@@ -30,6 +31,54 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     val io = IO.sleep(2.millis) *> IO(2)
 
     assertIO(io, returns = 3)
+  }
+
+  test("interceptIO works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+
+    interceptIO[IllegalArgumentException](io)
+  }
+
+  test("interceptIO works (failed assertion: different exception)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    interceptIO[IllegalArgumentException](io)
+  }
+
+  test("interceptIO works (sucessful assertion on `FailException`)") {
+    val io = IO(fail("BOOM!"))
+
+    interceptIO[FailException](io)
+  }
+
+  test("interceptIO works (failed assertion: IO does not fail)".fail) {
+    val io = IO(42)
+
+    interceptIO[IllegalArgumentException](io)
+  }
+
+  test("interceptMessageIO works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+
+    interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageIO works (failed assertion: different exception)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageIO works (failed assertion: different message)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageIO works (failed assertion: IO does not fail)".fail) {
+    val io = IO(42)
+
+    interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
   }
 
 }

--- a/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+import scala.concurrent.duration._
+
+class CatsEffectAssertionsSpec extends CatsEffectSuite {
+
+  test("assertIO works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIO(io, returns = 2)
+  }
+  test("assertIO works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIO(io, returns = 3)
+  }
+
+}

--- a/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -19,6 +19,7 @@ package munit
 import cats.effect.IO
 import cats.syntax.all._
 import scala.concurrent.duration._
+import cats.effect.SyncIO
 
 class CatsEffectAssertionsSpec extends CatsEffectSuite {
 
@@ -79,6 +80,65 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     val io = IO(42)
 
     interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("assertSyncIO works (successful assertion)") {
+    val io = SyncIO(2)
+
+    assertSyncIO(io, returns = 2)
+  }
+  test("assertSyncIO works (failed assertion)".fail) {
+    val io = SyncIO(2)
+
+    assertSyncIO(io, returns = 3)
+  }
+
+  test("interceptSyncIO works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+
+    interceptSyncIO[IllegalArgumentException](io)
+  }
+
+  test("interceptSyncIO works (failed assertion: different exception)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    interceptSyncIO[IllegalArgumentException](io)
+  }
+
+  test("interceptSyncIO works (sucessful assertion on `FailException`)") {
+    val io = SyncIO(fail("BOOM!"))
+
+    interceptSyncIO[FailException](io)
+  }
+
+  test("interceptSyncIO works (failed assertion: SyncIO does not fail)".fail) {
+    val io = SyncIO(42)
+
+    interceptSyncIO[IllegalArgumentException](io)
+  }
+
+  test("interceptMessageSyncIO works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+
+    interceptMessageSyncIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageSyncIO works (failed assertion: different exception)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    interceptMessageSyncIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageSyncIO works (failed assertion: different message)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    interceptMessageSyncIO[IllegalArgumentException]("BOOM!")(io)
+  }
+
+  test("interceptMessageSyncIO works (failed assertion: SyncIO does not fail)".fail) {
+    val io = SyncIO(42)
+
+    interceptMessageSyncIO[IllegalArgumentException]("BOOM!")(io)
   }
 
 }

--- a/core/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+import cats.syntax.all._
+import scala.concurrent.duration._
+import cats.effect.SyncIO
+
+class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
+
+  test("assertEquals (for IO) works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    io assertEquals 2
+  }
+  test("assertEquals (for IO) works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    io assertEquals 3
+  }
+
+  test("intercept (for IO) works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("intercept (for IO) works (failed assertion: different exception)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("intercept (for IO) works (sucessful assertion on `FailException`)") {
+    val io = IO(fail("BOOM!"))
+
+    io.intercept[FailException]
+  }
+
+  test("intercept (for IO) works (failed assertion: IO does not fail)".fail) {
+    val io = IO(42)
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("interceptMessage (for IO) works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for IO) works (failed assertion: different exception)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for IO) works (failed assertion: different message)".fail) {
+    val io = IO(fail("BOOM!"))
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for IO) works (failed assertion: IO does not fail)".fail) {
+    val io = IO(42)
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("assertEquals (for SyncIO) works (successful assertion)") {
+    val io = SyncIO(2)
+
+    io assertEquals 2
+  }
+  test("assertEquals (for SyncIO) works (failed assertion)".fail) {
+    val io = SyncIO(2)
+
+    io assertEquals 3
+  }
+
+  test("intercept (for SyncIO) works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("intercept (for SyncIO) works (failed assertion: different exception)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("intercept (for SyncIO) works (sucessful assertion on `FailException`)") {
+    val io = SyncIO(fail("BOOM!"))
+
+    io.intercept[FailException]
+  }
+
+  test("intercept (for SyncIO) works (failed assertion: SyncIO does not fail)".fail) {
+    val io = SyncIO(42)
+
+    io.intercept[IllegalArgumentException]
+  }
+
+  test("interceptMessage (for SyncIO) works (successful assertion)") {
+    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for SyncIO) works (failed assertion: different exception)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for SyncIO) works (failed assertion: different message)".fail) {
+    val io = SyncIO(fail("BOOM!"))
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+  test("interceptMessage (for SyncIO) works (failed assertion: SyncIO does not fail)".fail) {
+    val io = SyncIO(42)
+
+    io interceptMessage [IllegalArgumentException] "BOOM!"
+  }
+
+}

--- a/core/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -61,25 +61,25 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
   test("interceptMessage (for IO) works (successful assertion)") {
     val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for IO) works (failed assertion: different exception)".fail) {
     val io = IO(fail("BOOM!"))
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for IO) works (failed assertion: different message)".fail) {
     val io = IO(fail("BOOM!"))
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for IO) works (failed assertion: IO does not fail)".fail) {
     val io = IO(42)
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("assertEquals (for SyncIO) works (successful assertion)") {
@@ -120,25 +120,25 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
   test("interceptMessage (for SyncIO) works (successful assertion)") {
     val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for SyncIO) works (failed assertion: different exception)".fail) {
     val io = SyncIO(fail("BOOM!"))
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for SyncIO) works (failed assertion: different message)".fail) {
     val io = SyncIO(fail("BOOM!"))
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
   test("interceptMessage (for SyncIO) works (failed assertion: SyncIO does not fail)".fail) {
     val io = SyncIO(42)
 
-    io interceptMessage [IllegalArgumentException] "BOOM!"
+    io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
 
 }

--- a/core/shared/src/test/scala/munit/CatsEffectSuiteSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectSuiteSpec.scala
@@ -81,4 +81,14 @@ class CatsEffectSuiteSpec extends CatsEffectSuite {
           }
       }
   }
+  test("assertIO works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIO(io, returns = 2)
+  }
+  test("assertIO works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIO(io, returns = 3)
+  }
 }

--- a/core/shared/src/test/scala/munit/CatsEffectSuiteSpec.scala
+++ b/core/shared/src/test/scala/munit/CatsEffectSuiteSpec.scala
@@ -81,14 +81,4 @@ class CatsEffectSuiteSpec extends CatsEffectSuite {
           }
       }
   }
-  test("assertIO works (successful assertion)") {
-    val io = IO.sleep(2.millis) *> IO(2)
-
-    assertIO(io, returns = 2)
-  }
-  test("assertIO works (failed assertion)".fail) {
-    val io = IO.sleep(2.millis) *> IO(2)
-
-    assertIO(io, returns = 3)
-  }
 }


### PR DESCRIPTION
## Motivation

There are some cases when returning an IO can be not-very readable and can pollute the code with lots of `.flatMap(a => IO(assertEquals(a, "bla bla"))`. So it would be ideal to have a method to do this in a more readable way.

## What has been done in this PR?

Add an `assertIO` method that can be used in cases like this:

```scala
//before
myIO.flatMap(value => assertEquals(value, myExpectedValue))

//after
assertIO(myIO, returns = myExpectedValue)
```

**Update 18th Oct, 2020**

More assertions have been added:

- `interceptIO`, for intercepting a `Throwable` being thrown inside the provided `IO`:
```scala
val io = IO.raiseError[Unit](MyException("BOOM!"))

interceptIO[MyException](io)
```
- `interceptMessageIO`, for intercepting a `Throwable` with a certain message being thrown inside the provided `IO`:

```scala
val io = IO.raiseError[Unit](MyException("BOOM!"))

interceptIO[MyException]("BOOM!")(io)
```
- Also `*SyncIO` versions of all the previous assertions have been added.
- In addition, syntax version of all the assertions have been added (similar to Specs2/Scalatest DSL):

```scala
io assertEquals 2
io.intercept[IllegalArgumentException]
```