### PR TITLE
Add option to call `assert` on IO[Boolean]

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ class ExampleSuite extends CatsEffectSuite {
     IO(42).assertEquals(42)
   }
 
+  test("or via plain assert syntax on IO[Boolean]") {
+    IO(true).assert
+  }
+
   test("SyncIO works too") {
     SyncIO(42).assertEquals(42)
   }

--- a/ce3/shared/src/test/scala/munit/ExampleSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleSuite.scala
@@ -31,6 +31,10 @@ class ExampleSuite extends CatsEffectSuite {
     IO(42).assertEquals(42)
   }
 
+  test("or via plain assert syntax on IO[Boolean]") {
+    IO(true).assert
+  }
+
   test("SyncIO works too") {
     SyncIO(42).assertEquals(42)
   }

--- a/common/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/common/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -48,6 +48,25 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location, ev: B <:< A): IO[Unit] =
     obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
 
+  /** Asserts that an `IO[Boolean]` returns true.
+    *
+    * For example:
+    * {{{
+    *   assertIOBoolean(IO(true))
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the
+    * assertion fails.
+    *
+    * @param obtained the IO[Boolean] under testing
+    * @param clue a value that will be printed in case the assertions fails
+    */
+  protected def assertIOBoolean(
+      obtained: IO[Boolean],
+      clue: => Any = "values are not the same"
+  )(implicit loc: Location): IO[Unit] =
+    assertIO(obtained, true, clue)
+
   /** Intercepts a `Throwable` being thrown inside the provided `IO`.
     *
     * @example
@@ -249,6 +268,19 @@ trait CatsEffectAssertions { self: Assertions =>
     )(implicit T: ClassTag[T], loc: Location): IO[T] =
       interceptMessageIO[T](expectedExceptionMessage)(io)
 
+  }
+
+  implicit class MUnitCatsAssertionsForIOBooleanOps(io: IO[Boolean]) {
+
+    /** Asserts that this effect returns an expected value.
+      *
+      * For example:
+      * {{{
+      *   IO(true).assert // OK
+      * }}}
+      */
+    def assert(implicit loc: Location): IO[Unit] =
+      assertIOBoolean(io, "value is not true")
   }
 
   implicit class MUnitCatsAssertionsForSyncIOOps[A](io: SyncIO[A]) {

--- a/common/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/common/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -34,6 +34,17 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     io assertEquals 3
   }
 
+  test("assert (for IO) works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(true)
+
+    io.assert
+  }
+  test("assert (for IO) works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(false)
+
+    io.assert
+  }
+
   test("intercept (for IO) works (successful assertion)") {
     val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
 


### PR DESCRIPTION
I’m submitting this PR to propose that a syntax for `IO[Boolean]` be added.
I’m promoting the syntax `io.assert` over `io.assertEquals(true)`
The code changes are small but there are a couple of details I’ll note in comments below

Closes https://github.com/typelevel/munit-cats-effect/issues/50
