### PR TITLE
Update the library versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Integration library for [MUnit](https://scalameta.org/munit/) and [cats-effect](
 Cats Effect 2 integration is provided via:
 
 ```scala
-libraryDependencies += "org.typelevel" %%% "munit-cats-effect-2" % "0.11.0" % "test"
+libraryDependencies += "org.typelevel" %%% "munit-cats-effect-2" % "0.13.1" % "test"
 ```
 
 Cats Effect 3 integration is provided via:
 
 ```scala
-libraryDependencies += "org.typelevel" %%% "munit-cats-effect-3" % "0.11.0" % "test"
+libraryDependencies += "org.typelevel" %%% "munit-cats-effect-3" % "0.13.1" % "test"
 ```
 
 Builds are available for Scala 2.12, 2.13, and 3 for both the JVM and Scala.js.


### PR DESCRIPTION
The `assert` syntax on `IO[Boolean]` looks to be a fairly recent addition.