### PR TITLE
Add ResourceSuiteLocalFixture

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,15 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
     ),
     mimaPreviousArtifacts := Set.empty
   )
-  .jsSettings(scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
+  .jvmSettings(
+    Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/main/scala",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/test/scala"
+  )
+  .jsSettings(
+    Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/main/scala",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/test/scala",
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
 
 lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
@@ -82,7 +90,15 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
     ),
     mimaPreviousArtifacts := Set.empty
   )
-  .jsSettings(scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
+  .jvmSettings(
+    Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/main/scala",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/test/scala"
+  )
+  .jsSettings(
+    Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/main/scala",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/test/scala",
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
 
 addCommandAlias("fmt", """scalafmtSbt;scalafmtAll""")
 addCommandAlias("fmtCheck", """scalafmtSbtCheck;scalafmtCheckAll""")

--- a/ce2/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce2/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -23,6 +23,7 @@ import scala.concurrent.{Future, ExecutionContext}
 abstract class CatsEffectSuite
     extends FunSuite
     with CatsEffectAssertions
+    with CatsEffectFixtures
     with CatsEffectFunFixtures {
 
   implicit def munitContextShift: ContextShift[IO] =

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -24,6 +24,7 @@ import scala.concurrent.Future
 abstract class CatsEffectSuite
     extends FunSuite
     with CatsEffectAssertions
+    with CatsEffectFixtures
     with CatsEffectFunFixtures {
 
   implicit val ioRuntime: IORuntime = IORuntime.global

--- a/common/js/src/main/scala/munit/CatsEffectFixtures.scala
+++ b/common/js/src/main/scala/munit/CatsEffectFixtures.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+trait CatsEffectFixtures { self: CatsEffectSuite => }

--- a/common/jvm/src/main/scala/munit/CatsEffectFixtures.scala
+++ b/common/jvm/src/main/scala/munit/CatsEffectFixtures.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.{IO, Resource}
+
+trait CatsEffectFixtures { self: CatsEffectSuite =>
+
+  object ResourceSuiteLocalFixture {
+    def apply[T](name: String, resource: Resource[IO, T]): Fixture[T] =
+      new Fixture[T](name) {
+        var value: Option[(T, IO[Unit])] = None
+
+        def apply(): T = value.get._1
+
+        override def beforeAll(): Unit = {
+          val resourceEffect = resource.allocated
+          val (t, cleanup) = resourceEffect.unsafeRunSync()
+          value = Some(t -> cleanup)
+        }
+
+        override def afterAll(): Unit = {
+          value.get._2.unsafeRunSync()
+        }
+      }
+  }
+
+}

--- a/common/jvm/src/test/scala/munit/CatsEffectFixturesSpec.scala
+++ b/common/jvm/src/test/scala/munit/CatsEffectFixturesSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.{IO, Resource}
+
+class CatsEffectFixturesSpec extends CatsEffectSuite {
+
+  var acquired: Int = 0
+  var released: Int = 0
+
+  val fixture = ResourceSuiteLocalFixture(
+    "fixture",
+    Resource.make(
+      IO {
+        acquired += 1
+        ()
+      }
+    )(_ =>
+      IO {
+        released += 1
+        ()
+      }
+    )
+  )
+
+  override def munitFixtures = List(fixture)
+
+  override def beforeAll(): Unit = {
+    assertEquals(acquired, 0)
+    assertEquals(released, 0)
+  }
+
+  override def afterAll(): Unit = {
+    assertEquals(acquired, 1)
+    assertEquals(released, 1)
+  }
+
+  test("first test") {
+    IO(fixture()).assertEquals(())
+  }
+
+  test("second test") {
+    IO(fixture()).assertEquals(())
+  }
+
+}


### PR DESCRIPTION
Munit allows for suite-local test fixtures by defining a `Fixture` in conjunction with implementing `beforeAll` and `afterAll`. This is really useful in situations where you want to allocate a resource a single time for an entire suite (e.g. allocate one http connection pool for the whole suite rather than each test case individually). 

This PR adds that with this new `ResourceSuiteLocalFixture` companion object. I think it'll be very convenient for those who want it, but there are some tradeoffs:
1. We lose referential transparency with respect to the fixture object since it's inherently stateful.
2. The fixture _must_ be declared as a `val` or else tests will throw an exception.
3. We need to be able to synchronously allocate the resource because of how munit works. We can't synchronously evaluate `IO` on JS so it really only works on the JVM. I think we could define another `apply` constructor for `Resource[SyncIO, T]` that _does_ work on JS though.

So we're losing some ability to reason about the test fixtures, but I think it's reasonable to converge to a tighter munit integration. There might be an alternative implementation that works nicer, but I haven't thought about it yet. Interested in hearing more thoughts about this