### PR TITLE
Add more concise assertions for the Unit value

### DIFF
--- a/common/shared/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/common/shared/src/main/scala/munit/CatsEffectAssertions.scala
@@ -48,6 +48,25 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location, ev: B <:< A): IO[Unit] =
     obtained.flatMap(a => IO(assertEquals(a, returns, clue)))
 
+  /** Asserts that an `IO[Unit]` returns the Unit value.
+    *
+    * For example:
+    * {{{
+    *   assertIO_(IO.unit)
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the
+    * assertion fails.
+    *
+    * @param obtained the IO under testing
+    * @param clue a value that will be printed in case the assertions fails
+    */
+  protected def assertIO_(
+      obtained: IO[Unit],
+      clue: => Any = "value is not ()"
+  )(implicit loc: Location): IO[Unit] =
+    obtained.flatMap(a => IO(assertEquals(a, (), clue)))
+
   /** Asserts that an `IO[Boolean]` returns true.
     *
     * For example:
@@ -131,6 +150,25 @@ trait CatsEffectAssertions { self: Assertions =>
       clue: => Any = "values are not the same"
   )(implicit loc: Location, ev: B <:< A): SyncIO[Unit] =
     obtained.flatMap(a => SyncIO(assertEquals(a, returns, clue)))
+
+  /** Asserts that a `SyncIO[Unit]` returns the Unit value.
+    *
+    * For example:
+    * {{{
+    *   assertSyncIO_(SyncIO.unit) // OK
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the
+    * assertion fails.
+    *
+    * @param obtained the SyncIO under testing
+    * @param clue a value that will be printed in case the assertions fails
+    */
+  protected def assertSyncIO_(
+      obtained: SyncIO[Unit],
+      clue: => Any = "value is not ()"
+  )(implicit loc: Location): SyncIO[Unit] =
+    obtained.flatMap(a => SyncIO(assertEquals(a, (), clue)))
 
   /** Intercepts a `Throwable` being thrown inside the provided `SyncIO`.
     *
@@ -270,6 +308,19 @@ trait CatsEffectAssertions { self: Assertions =>
 
   }
 
+  implicit class MUnitCatsAssertionsForIOUnitOps(io: IO[Unit]) {
+
+    /** Asserts that this effect returns the Unit value.
+      *
+      * For example:
+      * {{{
+      *   IO.unit.assert // OK
+      * }}}
+      */
+    def assert(implicit loc: Location): IO[Unit] =
+      assertIO_(io)
+  }
+
   implicit class MUnitCatsAssertionsForIOBooleanOps(io: IO[Boolean]) {
 
     /** Asserts that this effect returns an expected value.
@@ -334,6 +385,18 @@ trait CatsEffectAssertions { self: Assertions =>
 
   }
 
+  implicit class MUnitCatsAssertionsForSyncIOUnitOps(io: SyncIO[Unit]) {
+
+    /** Asserts that this effect returns the Unit value.
+      *
+      * For example:
+      * {{{
+      *   SyncIO.unit.assert // OK
+      * }}}
+      */
+    def assert(implicit loc: Location): SyncIO[Unit] =
+      assertSyncIO_(io)
+  }
 }
 
 object CatsEffectAssertions extends Assertions with CatsEffectAssertions

--- a/common/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/common/shared/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -23,6 +23,8 @@ import cats.effect.SyncIO
 
 class CatsEffectAssertionsSpec extends CatsEffectSuite {
 
+  private val exception = new IllegalArgumentException("BOOM!")
+
   test("assertIO works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO(2)
 
@@ -34,8 +36,19 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     assertIO(io, returns = 3)
   }
 
+  test("assertIO_ works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO.unit
+
+    assertIO_(io)
+  }
+  test("assertIO_ works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO.raiseError[Unit](exception)
+
+    assertIO_(io)
+  }
+
   test("interceptIO works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+    val io = exception.raiseError[IO, Unit]
 
     interceptIO[IllegalArgumentException](io)
   }
@@ -59,7 +72,7 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
   }
 
   test("interceptMessageIO works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+    val io = exception.raiseError[IO, Unit]
 
     interceptMessageIO[IllegalArgumentException]("BOOM!")(io)
   }
@@ -87,14 +100,27 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
 
     assertSyncIO(io, returns = 2)
   }
+
   test("assertSyncIO works (failed assertion)".fail) {
     val io = SyncIO(2)
 
     assertSyncIO(io, returns = 3)
   }
 
+  test("assertSyncIO_ works (successful assertion)") {
+    val io = SyncIO.unit
+
+    assertSyncIO_(io)
+  }
+
+  test("assertSyncIO_ works (failed assertion)".fail) {
+    val io = SyncIO.raiseError[Unit](exception)
+
+    assertSyncIO_(io)
+  }
+
   test("interceptSyncIO works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+    val io = exception.raiseError[SyncIO, Unit]
 
     interceptSyncIO[IllegalArgumentException](io)
   }
@@ -118,7 +144,7 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
   }
 
   test("interceptMessageSyncIO works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+    val io = exception.raiseError[SyncIO, Unit]
 
     interceptMessageSyncIO[IllegalArgumentException]("BOOM!")(io)
   }

--- a/common/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/common/shared/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -23,30 +23,46 @@ import cats.effect.SyncIO
 
 class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
 
+  private val exception = new IllegalArgumentException("BOOM!")
+
   test("assertEquals (for IO) works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO(2)
 
     io assertEquals 2
   }
+
   test("assertEquals (for IO) works (failed assertion)".fail) {
     val io = IO.sleep(2.millis) *> IO(2)
 
     io assertEquals 3
   }
 
-  test("assert (for IO) works (successful assertion)") {
+  test("assert (for IO[Boolean]) works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO(true)
 
     io.assert
   }
-  test("assert (for IO) works (failed assertion)".fail) {
+
+  test("assert (for IO[Boolean]) works (failed assertion)".fail) {
     val io = IO.sleep(2.millis) *> IO(false)
 
     io.assert
   }
 
+  test("assert (for IO[Unit]) works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO.unit
+
+    io.assert
+  }
+
+  test("assert (for IO[Unit]) works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO.raiseError[Unit](exception)
+
+    io.assert
+  }
+
   test("intercept (for IO) works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+    val io = exception.raiseError[IO, Unit]
 
     io.intercept[IllegalArgumentException]
   }
@@ -70,7 +86,7 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
   }
 
   test("interceptMessage (for IO) works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[IO, Unit]
+    val io = exception.raiseError[IO, Unit]
 
     io.interceptMessage[IllegalArgumentException]("BOOM!")
   }
@@ -98,14 +114,27 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
 
     io assertEquals 2
   }
+
   test("assertEquals (for SyncIO) works (failed assertion)".fail) {
     val io = SyncIO(2)
 
     io assertEquals 3
   }
 
+  test("assert (for SyncIO[Unit]) works (successful assertion)") {
+    val io = SyncIO.unit
+
+    io.assert
+  }
+
+  test("assert (for SyncIO[Unit]) works (failed assertion)".fail) {
+    val io = SyncIO.raiseError[Unit](exception)
+
+    io.assert
+  }
+
   test("intercept (for SyncIO) works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+    val io = exception.raiseError[SyncIO, Unit]
 
     io.intercept[IllegalArgumentException]
   }
@@ -129,7 +158,7 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
   }
 
   test("interceptMessage (for SyncIO) works (successful assertion)") {
-    val io = (new IllegalArgumentException("BOOM!")).raiseError[SyncIO, Unit]
+    val io = exception.raiseError[SyncIO, Unit]
 
     io.interceptMessage[IllegalArgumentException]("BOOM!")
   }


### PR DESCRIPTION
The motivation for this was more readable methods for assertions of `IO[Unit]` and `SyncIO[Unit]` values.
```scala
assertIO_(IO.unit)
```
```scala
IO.unit.assert
```
is more readable then:
```scala
assertIO(IO.unit, ())
```
```scala
IO.unit.assertEquals(())
```

And the same for `SyncIO[Unit]`.