### PR TITLE
Add a paragraph about assertions composition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,40 @@ class ExampleSuite extends CatsEffectSuite {
 
 There are more assertion functions like `interceptIO` and `interceptMessageIO` as well as syntax versions `intercept` and `interceptMessage`. See the `CatsEffectAssertions` trait for full details.
 
+Every assertion in `CatsEffectAssertions` for IO-value or SyncIO-value is an IO computation under the hood. If you are planning to use multiple assertions per one test suite, therefore, they should be composed. Otherwise will calculate only the last assertion.
+
+```scala
+import cats.syntax.all._
+import cats.effect.{IO, SyncIO}
+import munit.CatsEffectSuite
+
+class MultipleAssertionsExampleSuite extends CatsEffectSuite {
+  test("multiple IO-assertions should be composed") {
+    assertIO(IO(42), 42) *>
+      assertIO_(IO.unit)
+  }
+
+  test("multiple IO-assertions should be composed via for-comprehension") {
+    for {
+      _ <- assertIO(IO(42), 42)
+      _ <- assertIO_(IO.unit)
+    } yield ()       
+  }
+
+  test("multiple SyncIO-assertions should be composed") {
+    assertSyncIO(SyncIO(42), 42) *>
+      assertSyncIO_(SyncIO.unit)
+  }
+    
+  test("multiple SyncIO-assertions should be composed via for-comprehension") {
+    for {
+      _ <- assertSyncIO(SyncIO(42), 42)
+      _ <- assertSyncIO_(SyncIO.unit)
+    } yield ()       
+  }
+}
+```
+
 ## Suite-local fixtures
 
 MUnit supports reusable suite-local fixtures that are instantiated only once for the entire test suite. This is useful when an expensive resource (like an HTTP client) is needed for each test case but it is undesirable to allocate a new one each time.


### PR DESCRIPTION
On one hand, it's common to use composition when dealing with IO, but that differs from core MUnit API for Future-computations. And from my point of view, it's worth to be highlighted in the docs.