### PR TITLE
Override munit ExecutionContext with one from IORuntime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
-      "io.vasilev" %%% "cats-effect" % "3.2-13-4551ba8"
+      "io.vasilev" %%% "cats-effect" % "3.2-23-cc99a6c"
     ),
     mimaPreviousArtifacts := Set.empty
   )

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
-      "org.typelevel" %%% "cats-effect" % "3.2.5"
+      "io.vasilev" %%% "cats-effect" % "3.3-77-1e0e47c"
     ),
     mimaPreviousArtifacts := Set.empty
   )

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
-      "io.vasilev" %%% "cats-effect" % "3.3-77-1e0e47c"
+      "io.vasilev" %%% "cats-effect" % "3.2-13-4551ba8"
     ),
     mimaPreviousArtifacts := Set.empty
   )

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -29,7 +29,7 @@ abstract class CatsEffectSuite
 
   implicit def munitIoRuntime: IORuntime = IORuntime.global
 
-  override val munitExecutionContext: ExecutionContext = munitIoRuntime.compute
+  override implicit val munitExecutionContext: ExecutionContext = munitIoRuntime.compute
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -27,9 +27,11 @@ abstract class CatsEffectSuite
     with CatsEffectFixtures
     with CatsEffectFunFixtures {
 
-  implicit val ioRuntime: IORuntime = IORuntime.global
+  def ioRuntime: IORuntime = IORuntime.global
 
-  override val munitExecutionContext: ExecutionContext = IORuntime.global.compute
+  implicit val ir: IORuntime = ioRuntime
+
+  override val munitExecutionContext: ExecutionContext = ioRuntime.compute
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -16,8 +16,8 @@
 
 package munit
 
-import cats.effect.{IO, SyncIO}
 import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, SyncIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,9 +27,7 @@ abstract class CatsEffectSuite
     with CatsEffectFixtures
     with CatsEffectFunFixtures {
 
-  def ioRuntime: IORuntime = IORuntime.global
-
-  implicit val ir: IORuntime = ioRuntime
+  implicit def munitIoRuntime: IORuntime = IORuntime.global
 
   override val munitExecutionContext: ExecutionContext = ioRuntime.compute
 

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -29,7 +29,7 @@ abstract class CatsEffectSuite
 
   implicit def munitIoRuntime: IORuntime = IORuntime.global
 
-  override val munitExecutionContext: ExecutionContext = ioRuntime.compute
+  override val munitExecutionContext: ExecutionContext = munitIoRuntime.compute
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -19,7 +19,7 @@ package munit
 import cats.effect.{IO, SyncIO}
 import cats.effect.unsafe.IORuntime
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class CatsEffectSuite
     extends FunSuite
@@ -28,6 +28,8 @@ abstract class CatsEffectSuite
     with CatsEffectFunFixtures {
 
   implicit val ioRuntime: IORuntime = IORuntime.global
+
+  override val munitExecutionContext: ExecutionContext = IORuntime.global.compute
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)

--- a/ce3/shared/src/test/scala/munit/ExampleSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleSuite.scala
@@ -23,7 +23,7 @@ class ExampleSuite extends CatsEffectSuite {
     IO(42).map(it => assertEquals(it, 42))
   }
 
-  test("alternatively, asertions can be written via assertIO") {
+  test("alternatively, assertions can be written via assertIO") {
     assertIO(IO(42), 42)
   }
 

--- a/ce3/shared/src/test/scala/munit/ExampleSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleSuite.scala
@@ -19,33 +19,7 @@ import munit.CatsEffectSuite
 
 class ExampleSuite extends CatsEffectSuite {
 
-//  override lazy val ioRuntime: IORuntime = {
-//    println(s"NUMBER OF PROCESSORS: ${Runtime.getRuntime().availableProcessors()}")
-//
-//    val (compute, compDown) =
-//      IORuntime.createDefaultComputeThreadPool(ioRuntime, threads = 2)
-//
-//    val (blocking, blockDown) =
-//      IORuntime.createDefaultBlockingExecutionContext()
-//
-//    val (scheduler, schedDown) =
-//      IORuntime.createDefaultScheduler()
-//
-//    IORuntime(
-//      compute,
-//      blocking,
-//      scheduler,
-//      { () =>
-//        compDown()
-//        blockDown()
-//        schedDown()
-//      },
-//      unsafe.IORuntimeConfig()
-//    )
-//  }
-
   test("tests can return IO[Unit] with assertions expressed via a map") {
-    println(s"NUMBER OF PROCESSORS: ${Runtime.getRuntime().availableProcessors()}")
     IO(42).map(it => assertEquals(it, 42))
   }
 

--- a/ce3/shared/src/test/scala/munit/ExampleSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleSuite.scala
@@ -19,7 +19,33 @@ import munit.CatsEffectSuite
 
 class ExampleSuite extends CatsEffectSuite {
 
+//  override lazy val ioRuntime: IORuntime = {
+//    println(s"NUMBER OF PROCESSORS: ${Runtime.getRuntime().availableProcessors()}")
+//
+//    val (compute, compDown) =
+//      IORuntime.createDefaultComputeThreadPool(ioRuntime, threads = 2)
+//
+//    val (blocking, blockDown) =
+//      IORuntime.createDefaultBlockingExecutionContext()
+//
+//    val (scheduler, schedDown) =
+//      IORuntime.createDefaultScheduler()
+//
+//    IORuntime(
+//      compute,
+//      blocking,
+//      scheduler,
+//      { () =>
+//        compDown()
+//        blockDown()
+//        schedDown()
+//      },
+//      unsafe.IORuntimeConfig()
+//    )
+//  }
+
   test("tests can return IO[Unit] with assertions expressed via a map") {
+    println(s"NUMBER OF PROCESSORS: ${Runtime.getRuntime().availableProcessors()}")
     IO(42).map(it => assertEquals(it, 42))
   }
 


### PR DESCRIPTION
Closes https://github.com/typelevel/munit-cats-effect/issues/110

This overrides the default munit `parasitic-execution-context` with the one from `IORuntime.global`. 

Not sure if tests can be added for ScalaJS on the issue that @djspiewak mentions as I have no ScalaJS knowledge.