### PR TITLE
Update Scala 2.12 to `2.12.15`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2, 2.12.14, 2.13.6]
+        scala: [3.0.2, 2.12.15, 2.13.6]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -113,12 +113,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.14)
+      - name: Download target directories (2.12.15)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.15-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.14)
+      - name: Inflate target directories (2.12.15)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / publishGithubUser := "milanvdm"
 ThisBuild / publishFullName := "Milan van der Meer"
 
-ThisBuild / crossScalaVersions := List("3.0.2", "2.12.14", "2.13.6")
+ThisBuild / crossScalaVersions := List("3.0.2", "2.12.15", "2.13.6")
 
 ThisBuild / spiewakCiReleaseSnapshots := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,10 @@ lazy val root = project
   .settings(
     libraryDependencies ++= (
       if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
-      else Seq(
-        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
-      )
+      else
+        Seq(
+          compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+        )
     )
   )
 
@@ -58,9 +59,10 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= (
       if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
-      else Seq(
-        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
-      )
+      else
+        Seq(
+          compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+        )
     ),
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
@@ -88,9 +90,10 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= (
       if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
-      else Seq(
-        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
-      )
+      else
+        Seq(
+          compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+        )
     ),
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,14 @@ lazy val root = project
   .in(file("."))
   .aggregate(ce3.jvm, ce3.js, ce2.jvm, ce2.js)
   .enablePlugins(NoPublishPlugin, SonatypeCiReleasePlugin)
+  .settings(
+    libraryDependencies ++= (
+      if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
+      else Seq(
+        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+      )
+    )
+  )
 
 lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
@@ -48,6 +56,12 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
     Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/shared/src/test/scala"
   )
   .settings(
+    libraryDependencies ++= (
+      if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
+      else Seq(
+        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+      )
+    ),
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
       "org.typelevel" %%% "cats-effect" % "3.2.8"
@@ -72,6 +86,12 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
     Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/shared/src/test/scala"
   )
   .settings(
+    libraryDependencies ++= (
+      if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
+      else Seq(
+        compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
+      )
+    ),
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
       "org.typelevel" %%% "cats-effect" % "2.5.3"


### PR DESCRIPTION
This updates Scala 2.12 to 2.12.15 and adds a straight dependency on `kind-projector`. Otherwise, it's needed to wait when underlying libs will be released with the recent `kind-projector`.