### PR TITLE
Add deterministic suite for cats-effect-3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
     ),
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "0.7.29",
-      "org.typelevel" %%% "cats-effect" % "3.2.9"
+      "org.typelevel" %%% "cats-effect" % "3.2.9",
+      "org.typelevel" %%% "cats-effect-testkit" % "3.3-162-2022ef9"
     ),
     mimaPreviousArtifacts := Set.empty
   )

--- a/ce3/shared/src/main/scala/munit/CatsEffectDeterministicSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectDeterministicSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.testkit.TestControl
+import cats.effect.IO
+
+/** Suite that runs an IO deterministically through [[cats.effect.testkit.TestControl]]. This suite
+  * would help to test programs that can cause deadlock which would otherwise complete normally.
+  * Also, it allows testing programs that involve [[IO.sleep]]s of any length to complete almost
+  * instantly with correct semantics. For more details, dig into [[TestControl.executeEmbed]].
+  */
+abstract class CatsEffectDeterministicSuite extends CatsEffectSuite {
+
+  /** Seed that used by [[TestControl.executeEmbed]] for an IO execution.
+    */
+  def ioExecutionSeed: Option[String] = None
+
+  override def munitValueTransforms: List[ValueTransform] =
+    super.munitValueTransforms.filterNot(_ == munitIOTransform) ++ List(
+      munitDeterministicIOTransform
+    )
+
+  private val munitDeterministicIOTransform: ValueTransform =
+    new ValueTransform(
+      "Deterministic IO",
+      { case e: IO[_] =>
+        TestControl.executeEmbed(e, munitIoRuntime.config, ioExecutionSeed).unsafeToFuture()
+      }
+    )
+
+}

--- a/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce3/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -35,7 +35,7 @@ abstract class CatsEffectSuite
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)
 
-  private val munitIOTransform: ValueTransform =
+  private[munit] val munitIOTransform: ValueTransform =
     new ValueTransform(
       "IO",
       { case e: IO[_] => e.unsafeToFuture() }

--- a/ce3/shared/src/test/scala/munit/ExampleCatsEffectDeterministicSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleCatsEffectDeterministicSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.std.Dispatcher
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, SyncIO}
+
+import scala.concurrent.CancellationException
+import scala.concurrent.duration._
+
+class ExampleCatsEffectDeterministicSuite extends CatsEffectDeterministicSuite {
+
+  private val simple = IO.unit
+
+  private val longSleeps = for {
+    first <- IO.monotonic
+    _ <- IO.sleep(1.hour)
+    second <- IO.monotonic
+    _ <- IO.race(IO.sleep(1.day), IO.sleep(1.day + 1.nanosecond))
+    third <- IO.monotonic
+  } yield (first.toCoarsest, second.toCoarsest, third.toCoarsest)
+
+  private val deadlock: IO[Unit] = IO.never
+
+  private class ExampleException() extends RuntimeException
+
+  test("tests should pass for simple IO") {
+    assertIO_(simple)
+  }
+
+  test("tests should pass for an IO with long sleeps") {
+    assertIO(longSleeps, (0.nanoseconds, 1.hour, 25.hours))
+  }
+
+  test("tests should fail because of a deadlock".fail) {
+    // that interception doesn't work because exception comes from the runtime, not from IO itself
+    interceptIO[TestControl.NonTerminationException](deadlock)
+  }
+
+  test("tests should intercept exception for an IO which produces an error") {
+    interceptIO[ExampleException](IO.raiseError[Unit](new ExampleException()))
+  }
+
+  test("tests should fail because of an IO which self-cancels".fail) {
+    // that interception doesn't work because exception comes from the runtime, not from IO itself
+    interceptIO[CancellationException](IO.canceled)
+  }
+
+  test("tests can return IO[Unit] with assertions expressed via a map") {
+    IO(42).map(it => assertEquals(it, 42))
+  }
+
+  test("alternatively, assertions can be written via assertIO") {
+    assertIO(IO(42), 42)
+  }
+
+  test("or via assertEquals syntax") {
+    IO(42).assertEquals(42)
+  }
+
+  test("or via plain assert syntax on IO[Boolean]") {
+    IO(true).assert
+  }
+
+  test("SyncIO works too") {
+    SyncIO(42).assertEquals(42)
+  }
+
+  private val dispatcher = ResourceFixture(Dispatcher[IO])
+
+  dispatcher.test("resources can be lifted to munit fixtures") { dsp =>
+    dsp.unsafeRunAndForget(IO(42))
+  }
+
+  dispatcher.test("resources can be lifted to munit fixtures again") { dsp =>
+    dsp.unsafeRunAndForget(IO(42))
+  }
+}

--- a/ce3/shared/src/test/scala/munit/ExampleSuite.scala
+++ b/ce3/shared/src/test/scala/munit/ExampleSuite.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+package munit
+
 import cats.effect.{IO, SyncIO}
-import munit.CatsEffectSuite
 
 class ExampleSuite extends CatsEffectSuite {
 


### PR DESCRIPTION
Fixes #123.

This is a draft because we are waiting for the release of the `cats-effect`.
This adds `CatsEffectDeterministicSuite` that runs every `IO`s via `TestControl.executeEmbed`. 
However, I'm not _so_ convinced about it. Perhaps, calling `TestControl.executeEmbed` is not so hard on the user side. And what's more - it's convenient for aims of runtime exception interception (e.g. deadlocks or cancellation). See [tests](https://github.com/typelevel/munit-cats-effect/compare/deterministic-suite?expand=1#diff-1bf2b56657c90f666cd0dbc4ebe75551002069a3db4f28bca78e4642d9b9a4c3R50) for more details on it.

What do you folks think about this?
I am sorry if my mention is not relevant @djspiewak @SystemFw @milanvdm 