### PR TITLE
Enable MiMa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,18 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
       "org.scalameta" %%% "munit" % "0.7.29",
       "org.typelevel" %%% "cats-effect" % "2.5.4"
     ),
-    mimaPreviousArtifacts := Set.empty
+    // we are checking binary compatibility from the 1.0.6 version
+    mimaPreviousArtifacts ~= { _.filter {
+      m =>
+        val (majorV, minorV, patchV) = {
+          val x = m.revision.split("\\.").toList.map(_.toInt)
+
+          (x.headOption, x.lift(1), x.lift(2))
+        }
+
+        if (majorV.contains(1) && minorV.contains(0)) patchV.exists(_ >= 6) else true
+      }
+    }
   )
   .jvmSettings(
     Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/main/scala",

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-effect" % "3.3.5"
     ),
     // we are checking binary compatibility from the 1.0.6 version
-    mimaPreviousArtifacts ~= { _.filter { m =>
+    mimaPreviousArtifacts ~= {
+      _.filter { m =>
         VersionNumber(m.revision).matchesSemVer(SemanticSelector(">=1.0.6"))
       }
     }
@@ -50,7 +51,8 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-effect" % "2.5.4"
     ),
     // we are checking binary compatibility from the 1.0.6 version
-    mimaPreviousArtifacts ~= { _.filter { m =>
+    mimaPreviousArtifacts ~= {
+      _.filter { m =>
         VersionNumber(m.revision).matchesSemVer(SemanticSelector(">=1.0.6"))
       }
     }

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,18 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
       "org.scalameta" %%% "munit" % "0.7.29",
       "org.typelevel" %%% "cats-effect" % "3.3.5"
     ),
-    mimaPreviousArtifacts := Set.empty
+    // we are checking binary compatibility from the 1.0.6 version
+    mimaPreviousArtifacts ~= { _.filter {
+      m =>
+        val (majorV, minorV, patchV) = {
+          val x = m.revision.split("\\.").toList.map(_.toInt)
+
+          (x.headOption, x.lift(1), x.lift(2))
+        }
+
+        if (majorV.contains(1) && minorV.contains(0)) patchV.exists(_ >= 6) else true
+      }
+    }
   )
   .jvmSettings(
     Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/main/scala",

--- a/build.sbt
+++ b/build.sbt
@@ -22,15 +22,8 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-effect" % "3.3.5"
     ),
     // we are checking binary compatibility from the 1.0.6 version
-    mimaPreviousArtifacts ~= { _.filter {
-      m =>
-        val (majorV, minorV, patchV) = {
-          val x = m.revision.split("\\.").toList.map(_.toInt)
-
-          (x.headOption, x.lift(1), x.lift(2))
-        }
-
-        if (majorV.contains(1) && minorV.contains(0)) patchV.exists(_ >= 6) else true
+    mimaPreviousArtifacts ~= { _.filter { m =>
+        VersionNumber(m.revision).matchesSemVer(SemanticSelector(">=1.0.6"))
       }
     }
   )
@@ -57,15 +50,8 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-effect" % "2.5.4"
     ),
     // we are checking binary compatibility from the 1.0.6 version
-    mimaPreviousArtifacts ~= { _.filter {
-      m =>
-        val (majorV, minorV, patchV) = {
-          val x = m.revision.split("\\.").toList.map(_.toInt)
-
-          (x.headOption, x.lift(1), x.lift(2))
-        }
-
-        if (majorV.contains(1) && minorV.contains(0)) patchV.exists(_ >= 6) else true
+    mimaPreviousArtifacts ~= { _.filter { m =>
+        VersionNumber(m.revision).matchesSemVer(SemanticSelector(">=1.0.6"))
       }
     }
   )


### PR DESCRIPTION
Fixes #190.
There are many different binary compatibility issues, so I suggest just starting checking binary compatibility from the `1.0.6` version (the last released is `1.0.7`). Any concerns about this?