### PR TITLE
Silence JS warnings for CE 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,10 +62,10 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
     Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/jvm/src/test/scala"
   )
   .jsSettings(
+    libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0",
     Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/main/scala",
     Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/test/scala",
-    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
-    scalacOptions += "-P:scalajs:nowarnGlobalExecutionContext"
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   )
 
 addCommandAlias("fmt", """scalafmtSbt;scalafmtAll""")

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,8 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
   .jsSettings(
     Compile / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/main/scala",
     Test / unmanagedSourceDirectories += baseDirectory.value / "../../common/js/src/test/scala",
-    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
+    scalacOptions += "-P:scalajs:nowarnGlobalExecutionContext"
   )
 
 addCommandAlias("fmt", """scalafmtSbt;scalafmtAll""")

--- a/ce2/js/src/main/scala/munit/CatsEffectSuitePlatform.scala
+++ b/ce2/js/src/main/scala/munit/CatsEffectSuitePlatform.scala
@@ -17,9 +17,14 @@
 package munit
 
 import cats.effect.IO
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor
+
+import scala.concurrent.ExecutionContext
 
 private[munit] trait CatsEffectSuitePlatform { self: CatsEffectSuite =>
 
   private[munit] def unsafeRunSyncOrForget[A](ioa: IO[A]): Unit = ioa.unsafeRunAsyncAndForget()
+
+  private[munit] def suiteExecutionContext: ExecutionContext = MacrotaskExecutor
 
 }

--- a/ce2/jvm/src/main/scala/munit/CatsEffectSuitePlatform.scala
+++ b/ce2/jvm/src/main/scala/munit/CatsEffectSuitePlatform.scala
@@ -18,11 +18,15 @@ package munit
 
 import cats.effect.IO
 
+import scala.concurrent.ExecutionContext
+
 private[munit] trait CatsEffectSuitePlatform { self: CatsEffectSuite =>
 
   private[munit] def unsafeRunSyncOrForget[A](ioa: IO[A]): Unit = {
     ioa.unsafeRunSync()
     ()
   }
+
+  private[munit] def suiteExecutionContext: ExecutionContext = ExecutionContext.global
 
 }

--- a/ce2/shared/src/main/scala/munit/CatsEffectSuite.scala
+++ b/ce2/shared/src/main/scala/munit/CatsEffectSuite.scala
@@ -27,11 +27,13 @@ abstract class CatsEffectSuite
     with CatsEffectFixtures
     with CatsEffectFunFixtures {
 
+  private val ec: ExecutionContext = suiteExecutionContext
+
   implicit def munitContextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+    IO.contextShift(ec)
 
   implicit def munitTimer: Timer[IO] =
-    IO.timer(ExecutionContext.global)
+    IO.timer(ec)
 
   override def munitValueTransforms: List[ValueTransform] =
     super.munitValueTransforms ++ List(munitIOTransform, munitSyncIOTransform)


### PR DESCRIPTION
Even if we don't use fatal warnings, it, all the same, strikes the eye on every compile, CI run.
```
The global execution context in Scala.js is based on JS Promises (microtasks).
[warn] Using it may prevent macrotasks (I/O, timers, UI rendering) from running reliably.
[warn] 
[warn] Unfortunately, there is no way with ECMAScript only to implement a performant
[warn] macrotask execution context (and hence Scala.js core does not contain one).
[warn] 
[warn] We recommend you use: https://github.com/scala-js/scala-js-macrotask-executor
[warn] Please refer to the README.md of that project for more details regarding
[warn] microtask vs. macrotask execution contexts.
[warn] 
[warn] If you do not care about macrotask fairness, you can silence this warning by:
[warn] - Adding @nowarn("cat=other") (Scala >= 2.13.x only)
[warn] - Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option
[warn] - Using scala.scalajs.concurrent.JSExecutionContext.queue
[warn]   (the implementation of ExecutionContext.global in Scala.js) directly.
[warn] 
[warn] If you do not care about performance, you can use
[warn] scala.scalajs.concurrent.QueueExecutionContext.timeouts().
[warn] It is based on setTimeout which makes it fair but slow (due to clamping)
[warn]                 
[warn]     IO.contextShift(ExecutionContext.global)
```