### PR TITLE
WIP Integrate with munit v1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val ce3 = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalameta" %%% "munit" % "0.7.29",
+      "org.scalameta" %%% "munit" % "1.0.0-M1",
       "org.typelevel" %%% "cats-effect" % "3.3.11"
     ),
     // we are checking binary compatibility from the 1.0.6 version
@@ -52,7 +52,7 @@ lazy val ce2 = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalameta" %%% "munit" % "0.7.29",
+      "org.scalameta" %%% "munit" % "1.0.0-M1",
       "org.typelevel" %%% "cats-effect" % "2.5.4"
     ),
     // we are checking binary compatibility from the 1.0.6 version

--- a/common/jvm/src/test/scala/munit/CatsEffectFixturesPlatformSpec.scala
+++ b/common/jvm/src/test/scala/munit/CatsEffectFixturesPlatformSpec.scala
@@ -33,7 +33,8 @@ class CatsEffectFixturesPlatformSpec extends CatsEffectSuite with CatsEffectAsse
       }
     )(_ =>
       IO.sleep(1.millis) *> IO {
-        released += 1
+        assertEquals(acquired, 1)
+        assertEquals(released, 1)
         ()
       }
     )
@@ -53,7 +54,9 @@ class CatsEffectFixturesPlatformSpec extends CatsEffectSuite with CatsEffectAsse
 
   override def afterAll(): Unit = {
     assertEquals(acquired, 1)
-    assertEquals(released, 1)
+    assertEquals(released, 0) // not yet released
+    released += 1
+    ()
   }
 
   test("first test") {


### PR DESCRIPTION
This PR is a work in progress to update to munit v1 which should be out "real soon now".

Test are currently failing because of a breaking change in munit v1.

From the [munit v1.0.0-M1 release notes](https://github.com/scalameta/munit/releases/tag/v1.0.0-M1):

> The `FunSuite.{afterEach,afterAll}` methods are now evaluated before custom fixtures instead of after custom fixtures. The ordering for `beforeAll` and `beforeEach` is unchanged. The diff below demonstrates an example, assuming you have a fixture named `myFixture` and a test suite named `MySuite`. In other words, `FunSuite.{before*,after*}` methods are now evaluated as a regular `Fixture[T]` that's always the first element of `munitFixtures: Seq[Fixture[_]]`.

The particular failure test is [CatsEffectFixturesPlatformSpec](https://github.com/typelevel/munit-cats-effect/blob/76df81a7377baeab58f5ae09b53f415b5ac8586d/common/jvm/src/test/scala/munit/CatsEffectFixturesPlatformSpec.scala) as it relies the old behaviour where the fixture's `afterAll` was called before the suite's `afterAll`.

With the new behaviour, the fixture's `afterAll` is the last thing called.
It's not immediately clear to me how we'd adapt this test to the new behaviour.