### PR TITLE
Implement test timeouts

### DIFF
--- a/core/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/src/main/scala/munit/CatsEffectSuite.scala
@@ -37,7 +37,7 @@ abstract class CatsEffectSuite
   override implicit def munitExecutionContext: ExecutionContext = munitIORuntime.compute
 
   /** The timeout for [[cats.effect.IO IO]]-based tests. When it expires it will gracefully cancel
-    * the fiber running the test and invoke any finalizers.
+    * the fiber running the test and invoke any finalizers before ultimately failing the test.
     *
     * Note that the fiber may still hang while running finalizers or even be uncancelable. In this
     * case the [[munitTimeout]] will take effect, with the caveat that the hanging fiber will be
@@ -49,9 +49,9 @@ abstract class CatsEffectSuite
     * [[scala.concurrent.Future Future]] or synchronous code. This is implemented by the MUnit
     * framework itself.
     *
-    * When this timeout expires, the suite will proceed without waiting for cancelation of the test
-    * or even attempting to cancel it. For that reason it is recommended to set this to a greater
-    * value than [[munitIOTimeout]], which performs graceful cancelation of
+    * When this timeout expires, the suite will immediately fail the test and proceed without
+    * waiting for its cancelation or even attempting to cancel it. For that reason it is recommended
+    * to set this to a greater value than [[munitIOTimeout]], which performs graceful cancelation of
     * [[cats.effect.IO IO]]-based tests. The default grace period for cancelation is 1 second.
     */
   override def munitTimeout: Duration = munitIOTimeout + 1.second

--- a/core/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/src/main/scala/munit/CatsEffectSuite.scala
@@ -36,9 +36,24 @@ abstract class CatsEffectSuite
 
   override implicit def munitExecutionContext: ExecutionContext = munitIORuntime.compute
 
+  /** The timeout for [[cats.effect.IO IO]]-based tests. When it expires it will gracefully cancel
+    * the fiber running the test and invoke any finalizers.
+    *
+    * Note that the fiber may still hang while running finalizers or even be uncancelable. In this
+    * case the [[munitTimeout]] will take effect, with the caveat that the hanging fiber will be
+    * leaked.
+    */
   def munitIOTimeout: Duration = 30.seconds
 
-  // buys us a 1s window to cancel the IO, before munit cancels the Future
+  /** The overall timeout applicable to all tests in the suite, including those written in terms of
+    * [[scala.concurrent.Future Future]] or synchronous code. This is implemented by the MUnit
+    * framework itself.
+    *
+    * When this timeout expires, the suite will proceed without waiting for cancelation of the test
+    * or even attempting to cancel it. For that reason it is recommended to set this to a greater
+    * value than [[munitIOTimeout]], which performs graceful cancelation of
+    * [[cats.effect.IO IO]]-based tests. The default grace period for cancelation is 1 second.
+    */
   override def munitTimeout: Duration = munitIOTimeout + 1.second
 
   override def munitValueTransforms: List[ValueTransform] =

--- a/core/src/test/scala/munit/CatsEffectSuiteSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectSuiteSpec.scala
@@ -18,8 +18,14 @@ package munit
 
 import cats.effect.{IO, SyncIO}
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class CatsEffectSuiteSpec extends CatsEffectSuite {
+
+  override def munitIOTimeout = 100.millis
+  override def munitTimeout = Int.MaxValue.nanos // so only our timeout is in effect
+
+  test("times out".fail) { IO.sleep(1.second) }
 
   test("nested IO fail".fail) { IO(IO(1)) }
   test("nested IO and SyncIO fail".fail) { IO(SyncIO(1)) }


### PR DESCRIPTION
FTR, MUnit already supports timeouts, but it comes with caveats:

1. It doesn't `.cancel` the `IO`, so finalizers are not run. Indeed, the `IO` doesn't even stop running, the test suite just continues!
2. It doesn't work on Scala Native, or even Scala.js (?) (see https://github.com/http4s/http4s/pull/6652#issuecomment-1238433673).

By implementing first-class support for timeouts in munit-cats-effect we can solve both of these problems.