### PR TITLE
Add migratory deprecation to `munitTimeout`

### DIFF
--- a/core/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/src/main/scala/munit/CatsEffectSuite.scala
@@ -54,6 +54,11 @@ abstract class CatsEffectSuite
     * to set this to a greater value than [[munitIOTimeout]], which performs graceful cancelation of
     * [[cats.effect.IO IO]]-based tests. The default grace period for cancelation is 1 second.
     */
+  @deprecatedOverriding(
+    "Override munitIOTimeout instead. This method will not be finalized, but the only reason to" +
+      "override it would be to adjust the grace period for fiber cancelation (default 1 second).",
+    "2.0.0"
+  )
   override def munitTimeout: Duration = munitIOTimeout + 1.second
 
   override def munitValueTransforms: List[ValueTransform] =

--- a/core/src/test/scala/munit/CatsEffectSuiteSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectSuiteSpec.scala
@@ -17,12 +17,15 @@
 package munit
 
 import cats.effect.{IO, SyncIO}
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class CatsEffectSuiteSpec extends CatsEffectSuite {
 
   override def munitIOTimeout = 100.millis
+
+  @nowarn
   override def munitTimeout = Int.MaxValue.nanos // so only our timeout is in effect
 
   test("times out".fail) { IO.sleep(1.second) }


### PR DESCRIPTION
This is a followup to https://github.com/typelevel/munit-cats-effect/pull/233. The problem is anyone who was overriding `munitTimeout` to be longer than 30 seconds will get tripped up by the new `munitIOTimeout` which will fire first.

So this PR adds a `@deprecatedOverriding` annotation to `munitTimeout` to indicate that `munitIOTimeout` should be used instead. It's not a _real_ deprecation, but it's unlikely a user will actually want to override `munitTimeout`.

@bpholt also suggests we can write a scalafix for this. We'd have to make sure that the test suite inherits from `CatsEffectSuite` before applying the rewrite. Any volunteers? 😁 