### PR TITLE
Add assert(predicate) syntax

### DIFF
--- a/core/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/src/main/scala/munit/CatsEffectAssertions.scala
@@ -93,30 +93,6 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location): IO[Unit] =
     assertIO(obtained, true, clue)
 
-  /** Asserts that an `IO[A]` satisfies a predicate.
-    *
-    * For example:
-    * {{{
-    *   assertIOPredicate(IO(false))(x => !x)
-    * }}}
-    *
-    * The "clue" value can be used to give extra information about the failure in case the assertion
-    * fails.
-    *
-    * @param obtained
-    *   the IO[A] under testing
-    * @param clue
-    *   a value that will be printed in case the assertions fails
-    * @param pred
-    *   the predicate that must be satisfied
-    */
-  protected def assertIOPredicate[A](
-      obtained: IO[A]
-  )(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
-      loc: Location
-  ): IO[Unit] =
-    assertIO(obtained.map(pred), true, clue)
-
   /** Intercepts a `Throwable` being thrown inside the provided `IO`.
     *
     * @example
@@ -206,29 +182,26 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location): SyncIO[Unit] =
     obtained.flatMap(a => SyncIO(assertEquals(a, (), clue)))
 
-  /** Asserts that a `SyncIO[A]` satisfies a predicate.
+  /** Asserts that a `SyncIO[Boolean]` returns true.
     *
     * For example:
     * {{{
-    *   assertSyncIOPredicate(SyncIO(false))(x => !x)
+    *   assertSyncIOBoolean(SyncIO(true))
     * }}}
     *
     * The "clue" value can be used to give extra information about the failure in case the assertion
     * fails.
     *
     * @param obtained
-    *   the SyncIO[A] under testing
+    *   the SyncIO[Boolean] under testing
     * @param clue
     *   a value that will be printed in case the assertions fails
-    * @param pred
-    *   the predicate that must be satisfied
     */
-  protected def assertSyncIOPredicate[A](
-      obtained: SyncIO[A]
-  )(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
-      loc: Location
-  ): SyncIO[Unit] =
-    assertSyncIO(obtained.map(pred), true, clue)
+  protected def assertSyncIOBoolean(
+      obtained: SyncIO[Boolean],
+      clue: => Any = "values are not the same"
+  )(implicit loc: Location): SyncIO[Unit] =
+    assertSyncIO(obtained, true, clue)
 
   /** Intercepts a `Throwable` being thrown inside the provided `SyncIO`.
     *
@@ -360,7 +333,7 @@ trait CatsEffectAssertions { self: Assertions =>
     def assert(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
         loc: Location
     ): IO[Unit] =
-      assertIOPredicate(io)(pred, clue)
+      assertIOBoolean(io.map(pred), clue)
 
     /** Intercepts a `Throwable` being thrown inside this effect.
       *
@@ -458,7 +431,7 @@ trait CatsEffectAssertions { self: Assertions =>
     def assert(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
         loc: Location
     ): SyncIO[Unit] =
-      assertSyncIOPredicate(io)(pred, clue)
+      assertSyncIOBoolean(io.map(pred), clue)
 
     /** Intercepts a `Throwable` being thrown inside this effect.
       *

--- a/core/src/main/scala/munit/CatsEffectAssertions.scala
+++ b/core/src/main/scala/munit/CatsEffectAssertions.scala
@@ -93,6 +93,30 @@ trait CatsEffectAssertions { self: Assertions =>
   )(implicit loc: Location): IO[Unit] =
     assertIO(obtained, true, clue)
 
+  /** Asserts that an `IO[A]` satisfies a predicate.
+    *
+    * For example:
+    * {{{
+    *   assertIOPredicate(IO(false))(x => !x)
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the assertion
+    * fails.
+    *
+    * @param obtained
+    *   the IO[A] under testing
+    * @param clue
+    *   a value that will be printed in case the assertions fails
+    * @param pred
+    *   the predicate that must be satisfied
+    */
+  protected def assertIOPredicate[A](
+      obtained: IO[A]
+  )(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
+      loc: Location
+  ): IO[Unit] =
+    assertIO(obtained.map(pred), true, clue)
+
   /** Intercepts a `Throwable` being thrown inside the provided `IO`.
     *
     * @example
@@ -181,6 +205,30 @@ trait CatsEffectAssertions { self: Assertions =>
       clue: => Any = "value is not ()"
   )(implicit loc: Location): SyncIO[Unit] =
     obtained.flatMap(a => SyncIO(assertEquals(a, (), clue)))
+
+  /** Asserts that a `SyncIO[A]` satisfies a predicate.
+    *
+    * For example:
+    * {{{
+    *   assertSyncIOPredicate(SyncIO(false))(x => !x)
+    * }}}
+    *
+    * The "clue" value can be used to give extra information about the failure in case the assertion
+    * fails.
+    *
+    * @param obtained
+    *   the SyncIO[A] under testing
+    * @param clue
+    *   a value that will be printed in case the assertions fails
+    * @param pred
+    *   the predicate that must be satisfied
+    */
+  protected def assertSyncIOPredicate[A](
+      obtained: SyncIO[A]
+  )(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
+      loc: Location
+  ): SyncIO[Unit] =
+    assertSyncIO(obtained.map(pred), true, clue)
 
   /** Intercepts a `Throwable` being thrown inside the provided `SyncIO`.
     *
@@ -295,6 +343,25 @@ trait CatsEffectAssertions { self: Assertions =>
     )(implicit loc: Location, ev: B <:< A): IO[Unit] =
       assertIO(io, expected, clue)
 
+    /** Asserts that this effect satisfies a given predicate.
+      *
+      * {{{
+      *  IO.pure(1).assert(_ > 0)
+      * }}}
+      *
+      * The "clue" value can be used to give extra information about the failure in case the
+      * assertion fails.
+      *
+      * @param pred
+      *   the predicate that must be satisfied
+      * @param clue
+      *   a value that will be printed in case the assertions fails
+      */
+    def assert(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
+        loc: Location
+    ): IO[Unit] =
+      assertIOPredicate(io)(pred, clue)
+
     /** Intercepts a `Throwable` being thrown inside this effect.
       *
       * @example
@@ -373,6 +440,25 @@ trait CatsEffectAssertions { self: Assertions =>
         clue: => Any = "values are not the same"
     )(implicit loc: Location, ev: B <:< A): SyncIO[Unit] =
       assertSyncIO(io, expected, clue)
+
+    /** Asserts that this effect satisfies a given predicate.
+      *
+      * {{{
+      *  SyncIO.pure(1).assert(_ > 0)
+      * }}}
+      *
+      * The "clue" value can be used to give extra information about the failure in case the
+      * assertion fails.
+      *
+      * @param pred
+      *   the predicate that must be satisfied
+      * @param clue
+      *   a value that will be printed in case the assertions fails
+      */
+    def assert(pred: A => Boolean, clue: => Any = "predicate not satisfied")(implicit
+        loc: Location
+    ): SyncIO[Unit] =
+      assertSyncIOPredicate(io)(pred, clue)
 
     /** Intercepts a `Throwable` being thrown inside this effect.
       *

--- a/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -52,7 +52,7 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
 
     assertIOBoolean(io)
   }
-  test("assertIO works (failed assertion)".fail) {
+  test("assertIOBoolean works (failed assertion)".fail) {
     val io = IO.sleep(2.millis) *> IO(false)
 
     assertIOBoolean(io)
@@ -135,7 +135,7 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
 
     assertSyncIOBoolean(io)
   }
-  test("assertSyncIO works (failed assertion)".fail) {
+  test("assertSyncIOBoolean works (failed assertion)".fail) {
     val io = SyncIO(false)
 
     assertSyncIOBoolean(io)

--- a/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -36,6 +36,17 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     assertIO(io, returns = 3)
   }
 
+  test("assertIOPredicate works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIOPredicate(io)(_ < 3)
+  }
+  test("assertIOPredicate works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    assertIOPredicate(io)(_ > 3)
+  }
+
   test("assertIO_ works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO.unit
 
@@ -105,6 +116,18 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     val io = SyncIO(2)
 
     assertSyncIO(io, returns = 3)
+  }
+
+  test("assertSyncIOPredicate works (successful assertion)") {
+    val io = SyncIO(2)
+
+    assertSyncIOPredicate(io)(_ < 3)
+  }
+
+  test("assertSyncIOPredicate works (failed assertion)".fail) {
+    val io = SyncIO(2)
+
+    assertSyncIOPredicate(io)(_ > 3)
   }
 
   test("assertSyncIO_ works (successful assertion)") {

--- a/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSpec.scala
@@ -36,17 +36,6 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     assertIO(io, returns = 3)
   }
 
-  test("assertIOPredicate works (successful assertion)") {
-    val io = IO.sleep(2.millis) *> IO(2)
-
-    assertIOPredicate(io)(_ < 3)
-  }
-  test("assertIOPredicate works (failed assertion)".fail) {
-    val io = IO.sleep(2.millis) *> IO(2)
-
-    assertIOPredicate(io)(_ > 3)
-  }
-
   test("assertIO_ works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO.unit
 
@@ -56,6 +45,17 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     val io = IO.sleep(2.millis) *> IO.raiseError[Unit](exception)
 
     assertIO_(io)
+  }
+
+  test("assertIOBoolean works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(true)
+
+    assertIOBoolean(io)
+  }
+  test("assertIO works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(false)
+
+    assertIOBoolean(io)
   }
 
   test("interceptIO works (successful assertion)") {
@@ -118,18 +118,6 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     assertSyncIO(io, returns = 3)
   }
 
-  test("assertSyncIOPredicate works (successful assertion)") {
-    val io = SyncIO(2)
-
-    assertSyncIOPredicate(io)(_ < 3)
-  }
-
-  test("assertSyncIOPredicate works (failed assertion)".fail) {
-    val io = SyncIO(2)
-
-    assertSyncIOPredicate(io)(_ > 3)
-  }
-
   test("assertSyncIO_ works (successful assertion)") {
     val io = SyncIO.unit
 
@@ -140,6 +128,17 @@ class CatsEffectAssertionsSpec extends CatsEffectSuite {
     val io = SyncIO.raiseError[Unit](exception)
 
     assertSyncIO_(io)
+  }
+
+  test("assertSyncIOBoolean works (successful assertion)") {
+    val io = SyncIO(true)
+
+    assertSyncIOBoolean(io)
+  }
+  test("assertSyncIO works (failed assertion)".fail) {
+    val io = SyncIO(false)
+
+    assertSyncIOBoolean(io)
   }
 
   test("interceptSyncIO works (successful assertion)") {

--- a/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -37,6 +37,18 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     io assertEquals 3
   }
 
+  test("assert predicate (for IO) works (successful assertion)") {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    io assert (_ < 3)
+  }
+
+  test("assert predicate (for IO) works (failed assertion)".fail) {
+    val io = IO.sleep(2.millis) *> IO(2)
+
+    io assert (_ > 3)
+  }
+
   test("assert (for IO[Boolean]) works (successful assertion)") {
     val io = IO.sleep(2.millis) *> IO(true)
 
@@ -119,6 +131,18 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     val io = SyncIO(2)
 
     io assertEquals 3
+  }
+
+  test("assert predicate (for SyncIO) works (successful assertion)") {
+    val io = SyncIO(2)
+
+    io assert (_ < 3)
+  }
+
+  test("assert predicate (for SyncIO) works (failed assertion)".fail) {
+    val io = SyncIO(2)
+
+    io assert (_ > 3)
   }
 
   test("assert (for SyncIO[Unit]) works (successful assertion)") {


### PR DESCRIPTION
Enables `IO.pure(1).assert(_ > 0)` syntax