### PR TITLE
fix typo (asertions => assertions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class ExampleSuite extends CatsEffectSuite {
     IO(42).map(it => assertEquals(it, 42))
   }
 
-  test("alternatively, asertions can be written via assertIO") {
+  test("alternatively, assertions can be written via assertIO") {
     assertIO(IO(42), 42)
   }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ class ExampleSuite extends CatsEffectSuite {
     IO(42).map(it => assertEquals(it, 42))
   }
 
-  test("alternatively, asertions can be written via assertIO") {
+  test("alternatively, assertions can be written via assertIO") {
     assertIO(IO(42), 42)
   }
 


### PR DESCRIPTION
I was reading through the code and noticed a typo in the spelling of assertions.  Thank you for all the work on this project!