### PR TITLE
Restore tests that assert fixture ordering after munit-1.0.0-M11 release

### DIFF
--- a/core/src/test/scala/munit/CatsEffectFixturesSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectFixturesSpec.scala
@@ -46,35 +46,17 @@ class CatsEffectFixturesSpec extends CatsEffectSuite with CatsEffectAssertions {
     Resource.make(IO.unit)(_ => IO.unit)
   )
 
-  object AssertBeforeFixture extends Fixture[Unit]("assertBefore") {
-    def apply() = ()
+  override def munitFixtures: Seq[AnyFixture[_]] = List(fixture)
 
-    override def beforeAll(): Unit = {
-      assertEquals(acquired, 0)
-      assertEquals(released, 0)
-    }
-
-    override def afterAll(): Unit = {
-      assertEquals(acquired, 1)
-      assertEquals(released, 0)
-    }
+  override def beforeAll(): Unit = {
+    assertEquals(acquired, 0)
+    assertEquals(released, 0)
   }
 
-  object AssertAfterFixture extends Fixture[Unit]("assertAfter") {
-    def apply() = ()
-
-    override def beforeAll(): Unit = {
-      assertEquals(acquired, 1)
-      assertEquals(released, 0)
-    }
-
-    override def afterAll(): Unit = {
-      assertEquals(acquired, 1)
-      assertEquals(released, 1)
-    }
+  override def afterAll(): Unit = {
+    assertEquals(acquired, 1)
+    assertEquals(released, 1)
   }
-
-  override def munitFixtures = List[AnyFixture[_]](AssertBeforeFixture, fixture, AssertAfterFixture)
 
   test("first test") {
     IO(fixture()).assertEquals(())


### PR DESCRIPTION
munit reverted back to the fixture ordering used before the 1.0.0 milestones. 
This PR brings back the original unit test

The change was the following commit https://github.com/typelevel/munit-cats-effect/pull/223/commits/98ecf0648a1e7406057ee129a9ad11a965be1e52 as part of #223

Fixes #359 
