### PR TITLE
Use CE 3.4 API directly

### DIFF
--- a/core/src/main/scala/munit/CatsEffectSuite.scala
+++ b/core/src/main/scala/munit/CatsEffectSuite.scala
@@ -70,14 +70,10 @@ abstract class CatsEffectSuite
       { case e: IO[_] =>
         val unnestedIO = checkNestingIO(e)
 
-        // TODO cleanup after CE 3.4.0 is released
-        val fd = Some(munitIOTimeout).collect { case fd: FiniteDuration => fd }
-        val timedIO = fd.fold(unnestedIO) { duration =>
-          unnestedIO.timeoutTo(
-            duration,
-            IO.raiseError(new TimeoutException(s"test timed out after $duration"))
-          )
-        }
+        val timedIO = unnestedIO.timeoutTo(
+          munitIOTimeout,
+          IO.raiseError(new TimeoutException(s"test timed out after $munitIOTimeout"))
+        )
 
         timedIO.unsafeToFuture()
       }


### PR DESCRIPTION
CE 3.4 no longer requires to convert `munitIOTimeout` into a `FiniteDuration` (https://github.com/typelevel/cats-effect/pull/2954)

See: #233