### PR TITLE
Propose value/effect extractor syntax

### DIFF
--- a/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -73,20 +73,20 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     io.assert
   }
 
-  test("mapOrFail (for IO) works (successful extraction)") {
+  test("mapOrFail (for IO) works (successful mapping)") {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
     io.mapOrFail { case Some(obtained) if obtained % 2 == 0 => obtained / 2 }
       .assertEquals(21)
   }
 
-  test("mapOrFail (for IO) works (failed extraction)".fail) {
+  test("mapOrFail (for IO) works (failed mapping)".fail) {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
     io.mapOrFail { case Some(obtained) if obtained % 2 == 1 => () }
   }
 
-  test("mapOrFail (for IO) works (failed extraction with clue)".fail) {
+  test("mapOrFail (for IO) works (failed mapping with clue)".fail) {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
     // This test simply shows what the syntax looks like when a `clue` is provided.
@@ -178,6 +178,29 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     val io = SyncIO.raiseError[Unit](exception)
 
     io.assert
+  }
+
+  test("mapOrFail (for SyncIO) works (successful mapping)") {
+    val io = SyncIO.pure(Some(42))
+
+    io.mapOrFail { case Some(obtained) if obtained % 2 == 0 => obtained / 2 }
+      .assertEquals(21)
+  }
+
+  test("mapOrFail (for SyncIO) works (failed mapping)".fail) {
+    val io = SyncIO.pure(Some(42))
+
+    io.mapOrFail { case Some(obtained) if obtained % 2 == 1 => () }
+  }
+
+  test("mapOrFail (for SyncIO) works (failed mapping with clue)".fail) {
+    val io = SyncIO.pure(Some(42))
+
+    // This test simply shows what the syntax looks like when a `clue` is provided.
+    io.mapOrFail(
+      { case Some(obtained) if obtained % 2 == 1 => () },
+      "the clue goes here"
+    )
   }
 
   test("intercept (for SyncIO) works (successful assertion)") {

--- a/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -73,24 +73,24 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     io.assert
   }
 
-  test("collectOrFail (for IO) works (successful extraction)") {
+  test("mapOrFail (for IO) works (successful extraction)") {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
-    io.collectOrFail { case Some(obtained) if obtained % 2 == 0 => obtained / 2 }
+    io.mapOrFail { case Some(obtained) if obtained % 2 == 0 => obtained / 2 }
       .assertEquals(21)
   }
 
-  test("collectOrFail (for IO) works (failed extraction)".fail) {
+  test("mapOrFail (for IO) works (failed extraction)".fail) {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
-    io.collectOrFail { case Some(obtained) if obtained % 2 == 1 => () }
+    io.mapOrFail { case Some(obtained) if obtained % 2 == 1 => () }
   }
 
-  test("collectOrFail (for IO) works (failed extraction with clue)".fail) {
+  test("mapOrFail (for IO) works (failed extraction with clue)".fail) {
     val io = IO.sleep(2.millis) *> IO.some(42)
 
     // This test simply shows what the syntax looks like when a `clue` is provided.
-    io.collectOrFail(
+    io.mapOrFail(
       { case Some(obtained) if obtained % 2 == 1 => () },
       "the clue goes here"
     )

--- a/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
+++ b/core/src/test/scala/munit/CatsEffectAssertionsSyntaxSpec.scala
@@ -73,6 +73,29 @@ class CatsEffectAssertionsSyntaxSpec extends CatsEffectSuite {
     io.assert
   }
 
+  test("collectOrFail (for IO) works (successful extraction)") {
+    val io = IO.sleep(2.millis) *> IO.some(42)
+
+    io.collectOrFail { case Some(obtained) if obtained % 2 == 0 => obtained / 2 }
+      .assertEquals(21)
+  }
+
+  test("collectOrFail (for IO) works (failed extraction)".fail) {
+    val io = IO.sleep(2.millis) *> IO.some(42)
+
+    io.collectOrFail { case Some(obtained) if obtained % 2 == 1 => () }
+  }
+
+  test("collectOrFail (for IO) works (failed extraction with clue)".fail) {
+    val io = IO.sleep(2.millis) *> IO.some(42)
+
+    // This test simply shows what the syntax looks like when a `clue` is provided.
+    io.collectOrFail(
+      { case Some(obtained) if obtained % 2 == 1 => () },
+      "the clue goes here"
+    )
+  }
+
   test("intercept (for IO) works (successful assertion)") {
     val io = exception.raiseError[IO, Unit]
 


### PR DESCRIPTION
A simplified example:
```scala
case class Record(id: Int, firstName: String, lastName: String, age: Int, etc: ...)

case class Response(status: Int, body: Stream[IO, Byte])

def decodeRecords: Pipe[IO, Byte, Record] = ???

// run
val request = Request(...).withQueryParam("firstName" -> "Elsa", "limit" -> 5)
val response: IO[Response] = client.get(request)

// check
response
  .collectOrFail { 
    case Response(200, body) => body
    case Response(204, _) => Stream.empty // just to show multiple cases
  }
  .flatMap(_
    .through(decodeRecords).
    .compile.toList)
  .assert { records =>
    records.forall(_.name == "Elsa") && records.size <= 5
  }
```
Without such a method the test would have to add a fallback case like this:
```scala
  .map { 
    case Response(200, body) => body
    case Response(204, _) => Stream.empty
    case _ => fail("unexpected response")
  }
```
which would not only create a lot of boilerplate (imagine a suite with many tests with similar checks), but would also be an "unsafe" operation in general. In order to make it safer we would have to create even more boilerplate:
```scala
  .flatMap { 
    case Response(200, body) => IO.pure(body)
    case Response(204, _) => IO.pure(Stream.empty)
    case _ => IO(fail("unexpected response"))
  }
```
which in turn might not be exactly convenient.